### PR TITLE
ci: add GHCR publish workflow + JaCoCo artifact; docs: refresh contacts & add CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,33 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
+    pull_request:
+        branches: [ main ]
+    push:
+        branches: [ main ]
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'maven'
-      - name: Build & Test auth-module only
-        run: mvn -B -Dspring.profiles.active=test -pl auth-module -am verify
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: surefire-reports
-          path: '**/target/surefire-reports/*.xml'
+    build-test:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    distribution: 'temurin'
+                    java-version: '17'
+                    cache: 'maven'
+            -   name: Build & Test auth-module only
+                run: mvn -B -Dspring.profiles.active=test -pl auth-module -am verify
+                         - name: Upload JaCoCo report
+                         uses: actions/upload-artifact@v4
+                         with:
+                             name: jacoco-report
+                             path: '**/target/site/jacoco'
+
+            -   name: Upload test reports
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: surefire-reports
+                    path: '**/target/surefire-reports/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ develop, main ]
-  push:
     branches: [ main ]
+  push:
+    branches: [ develop, main ]
 
 jobs:
   build-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
   push:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,36 @@
 name: CI
 
 on:
-    pull_request:
-        branches: [ main ]
-    push:
-        branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
 
 jobs:
-    build-test:
-        runs-on: ubuntu-latest
-        steps:
-            -   uses: actions/checkout@v4
-            -   name: Set up JDK 17
-                uses: actions/setup-java@v4
-                with:
-                    distribution: 'temurin'
-                    java-version: '17'
-                    cache: 'maven'
-            -   name: Build & Test auth-module only
-                run: mvn -B -Dspring.profiles.active=test -pl auth-module -am verify
-                         - name: Upload JaCoCo report
-                         uses: actions/upload-artifact@v4
-                         with:
-                             name: jacoco-report
-                             path: '**/target/site/jacoco'
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      -   name: Build & Test auth-module only
+          run: mvn -B -Dspring.profiles.active=test -pl auth-module -am verify
 
-            -   name: Upload test reports
-                if: always()
-                uses: actions/upload-artifact@v4
-                with:
-                    name: surefire-reports
-                    path: '**/target/surefire-reports/*.xml'
+      -   name: Upload JaCoCo report
+          if: always()
+          uses: actions/upload-artifact@v4
+          with:
+              name: jacoco-report
+              path: '**/target/site/jacoco'
+
+      -   name: Upload test reports
+          if: always()
+          uses: actions/upload-artifact@v4
+          with:
+              name: surefire-reports
+              path: '**/target/surefire-reports/*.xml'
+

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,48 @@
+name: Publish Docker (GHCR)
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    build-and-push:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: temurin
+                  java-version: '21'
+
+            - name: Build JAR
+              run: mvn -B -ntp -DskipTests package
+
+            - name: Log in to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract image metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ghcr.io/${{ github.repository }}
+                  tags: |
+                      type=ref,event=tag
+                      type=sha
+
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Summary
- Updated README contacts (mailto), added CI status badge.
- Added workflow to build & push Docker image to GHCR on release.
- CI uploads JaCoCo HTML report as artifact.

Why
- Showcase-ready main: visible CI status, reproducible artifact delivery.

Verification
- CI green on this PR.
- After merge: create release tag (e.g., v1.0.1) → image appears in GHCR, artifact available in Actions.

Checklist
- [x] CI passes
- [x] README updated
- [x] GHCR publish workflow added
- [x] JaCoCo report uploaded as artifact
