### PR TITLE
ci(publish): fix GHCR publish (auth-module context + prebuild JAR)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -21,7 +21,7 @@ jobs:
                   java-version: '21'
 
             - name: Build JAR
-              run: mvn -B -ntp -DskipTests package
+              run: mvn -B -ntp -DskipTests package -pl auth-module -am
 
             - name: Log in to GHCR
               uses: docker/login-action@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,17 +10,19 @@ jobs:
         permissions:
             contents: read
             packages: write
+
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Set up JDK
+            - name: Set up JDK 21
               uses: actions/setup-java@v4
               with:
                   distribution: temurin
                   java-version: '21'
 
-            - name: Build JAR
+            # собираем JAR только для модуля auth-module (нужен для COPY target/*.jar в Dockerfile)
+            - name: Build auth-module JAR
               run: mvn -B -ntp -DskipTests package -pl auth-module -am
 
             - name: Log in to GHCR
@@ -30,19 +32,21 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
+            # имя образа: ghcr.io/<owner>/<repo>-auth : <tag> и : <sha>
             - name: Extract image metadata
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ghcr.io/${{ github.repository }}
+                  images: ghcr.io/${{ github.repository }}-auth
                   tags: |
                       type=ref,event=tag
                       type=sha
 
-            - name: Build and push
+            - name: Build and push image
               uses: docker/build-push-action@v6
               with:
-                  context: .
+                  context: auth-module
+                  file: auth-module/Dockerfile
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Why
- Previous release run failed: Dockerfile searched in repo root; our Dockerfile is in auth-module.

What
- Build auth-module JAR before docker build.
- Set build context/file to auth-module.
- Publish image as ghcr.io/<owner>/<repo>-auth with :tag and :sha.

Verify
1) Merge PR (CI green).
2) Create new release (e.g., v1.0.2) targeting main.
3) Check Actions “Publish Docker (GHCR)” → green; image appears in Packages (set Public).
