### PR TITLE
docs: PR template + release badge + release notes; chore: dockerignore; chore: dependabot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.idea
+.mvn
+target
+**/target
+.env
+.env.*
+docker-compose*.yml
+README.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+- What & Why (short)
+
+## Changes
+- bullets
+
+## Verify
+- [ ] CI green
+- [ ] Local run ok (`docker compose up`)
+
+## Checklist
+- [ ] README updated (if needed)
+- [ ] Tests adjusted (if needed)

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,8 @@
+## What’s new
+- …
+
+## Tech
+- CI/CD: GHCR publish, CI badge
+
+## Run
+- `docker compose -f docker-compose.yml -f docker-compose.image.yml up -d --no-build`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: "maven"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 
 # 🏠 Rent Apartment App — Java Spring Boot microservices
 
+[![Release](https://img.shields.io/github/v/release/s-u-p-e-r-m-a-n/rent-apartment-app?include_prereleases)](../../releases)
+
+[![CI](https://github.com/s-u-p-e-r-m-a-n/rent-apartment-app/actions/workflows/ci.yml/badge.svg)](https://github.com/s-u-p-e-r-m-a-n/rent-apartment-app/actions/workflows/ci.yml)
+
+
+
+
 Монорепозиторий pet-проекта сервиса аренды жилья.  
 Архитектура на базе микросервисов: отдельный модуль авторизации, модуль работы с апартаментами, сервис отправки писем, API Gateway и сервис-дискавери (Eureka).
 
@@ -194,6 +201,4 @@ Sergey A. — ** Java Backend Developer **
 
 📄 Лицензия
 Проект распространяется под MIT License и может свободно использоваться для учебных и pet-проектов.
-## статус бейдж CI
-![CI](https://github.com/s-u-p-e-r-m-a-n/rent-apartment-app/actions/workflows/ci.yml/badge.svg)
-(https://github.com/s-u-p-e-r-m-a-n/rent-apartment-app/actions/workflows/ci.yml)
+

--- a/auth-module/.dockerignore
+++ b/auth-module/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.idea
+.mvn
+target
+**/target
+.env
+.env.*
+docker-compose*.yml
+README.md


### PR DESCRIPTION
Summary
- PR template, latest release badge, release notes template.
- .dockerignore (root + auth-module).
- Dependabot for Maven and GitHub Actions (weekly).

Why
- Portfolio polish: consistent PRs, visible release, smaller build context, deps hygiene.

Verify
- CI green, README shows badges.
